### PR TITLE
Modify LastWriteTime on ISO after download has completed

### DIFF
--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
@@ -360,8 +360,10 @@ If ($jobIdExists -and !(Test-Path -Path $isoFilePath)) {
                         $hash = (Get-FileHash -Path $isoFilePath -Algorithm 'SHA256').Hash
                         $outputLog = "!Error: The hash doesn't match!! You will need to collect the hash manually and add it to the script. The ISO's hash is -> $hash", $outputLog
                     } Else {
-                        $outputLog = "!Success: The hash matches! The file is all good! Removing cached JobId from registry and exiting Script!", $outputLog
+                        $outputLog = "!Success: The hash matches! The file is all good! Removing cached JobId from registry, changing LastWriteTime to NOW (so that disk cleanup doesn't delete it), and exiting Script!", $outputLog
                         Remove-RegistryValue -Name $jobIdKey
+                        # Change the LastWriteTime to now b/c otherwise, the disk cleanup script will wipe it out
+                        (Get-Item -Path $isoFilePath).LastWriteTime = Get-Date
                     }
 
                     Invoke-Output $outputLog


### PR DESCRIPTION
If we don't do this, the disk cleanup script will delete this file as soon as 30 days from ISO release has elapsed