### PR TITLE
Get-WindowsIsoUrl now requires `-Win` parameter and file has been renamed

### DIFF
--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
@@ -180,8 +180,8 @@ function Start-FileDownload {
     If ($isEnterprise) {
         $downloadUrl = $automateURL
     } Else {
-        (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.GetWindowsIsoUrl.ps1') | Invoke-Expression
-        $fido = Get-WindowsIsoUrl -Rel $automateWin10Build
+        (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-WindowsIsoUrl.ps1') | Invoke-Expression
+        $fido = Get-WindowsIsoUrl -Rel $automateWin10Build -Win 10
 
         $downloadUrl = $fido.Link
     }


### PR DESCRIPTION
This should be merged at the same time as PR for Get-WindowsIsoUrl: https://github.com/dkbrookie/PowershellFunctions/pull/13