### PR TITLE
Handle extra output from powershell polluting `installationAttemptCount`

### DIFF
--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
@@ -13,7 +13,7 @@ If (!$installationAttemptCount) {
 
 function Invoke-Output {
     param ([string[]]$output, [string[]]$automateOutputParams)
-    Write-Output "outputLog=$($output -join "`n")|installationAttemptCount=$installationAttemptCount"
+    Write-Output "outputLog=$($output -join "`n")|installationAttemptCount=$installationAttemptCount|additionalOutput="
 }
 
 function Get-ErrorMessage {

--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
@@ -13,7 +13,7 @@ If (!$installationAttemptCount) {
 
 function Invoke-Output {
     param ([string[]]$output, [string[]]$automateOutputParams)
-    Write-Output "outputLog=$($output -join "`n")|installationAttemptCount=$installationAttemptCount|additionalOutput="
+    Write-Output "installationAttemptCount=$installationAttemptCount|outputLog=$($output -join "`n")"
 }
 
 function Get-ErrorMessage {


### PR DESCRIPTION
We're ending up with output in the `installationAttemptCount` variable like this:


```
0
 Exception calling ""DownloadString"" with ""1"" argument(s): ""Unable to connect to the remote server""
At line:25 char:1
+ (New-Object Net.WebClient).DownloadString('https://raw.githubusercont/ ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException"
```

Which means that powershell is tacking some additional error output to the end of the string. I'd prefer it end up in a separate variable if powershell is going to tack output to the end.