### PR TITLE
Fix a typo and add a `Catch`

### DIFF
--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
@@ -41,7 +41,14 @@ If (!$Is64) {
     Return
 }
 
-$isEnterprise = (Get-WindowsEdition -Online).Edition -eq 'Enterprise'
+# This errors sometimes. If it does, we want a clear and actionable error and we do not want to continue
+Try {
+    $isEnterprise = (Get-WindowsEdition -Online).Edition -eq 'Enterprise'
+} Catch {
+    $outputLog += "There was an error in determining whether this is an Enterprise version of windows or not. The error was: $_"
+    Invoke-Output $outputLog
+    Return
+}
 
 # Make sure a URL has been defined for the Win10 ISO on Enterprise versions
 If ($isEnterprise -and !$automateURL) {

--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
@@ -38,7 +38,14 @@ If (!$automateWin10Build) {
     Return
 }
 
-$isEnterprise = (Get-WindowsEdition -Online).Edition -eq 'Enterprise'
+# This errors sometimes. If it does, we want a clear and actionable error and we do not want to continue
+Try {
+    $isEnterprise = (Get-WindowsEdition -Online).Edition -eq 'Enterprise'
+} Catch {
+    $outputLog += "There was an error in determining whether this is an Enterprise version of windows or not. The error was: $_"
+    Invoke-Output $outputLog
+    Return
+}
 
 # Make sure a URL has been defined for the Win10 ISO on Enterprise versions
 If ($isEnterprise -and !$automateURL) {

--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
@@ -176,7 +176,7 @@ function Get-HashCheck {
 
 function Read-PendingRebootStatus {
     $out = @()
-    $rebootChecks = $()
+    $rebootChecks = @()
 
      ## The following two reboot keys most commonly exist if a reboot is required for Windows Updates, but it is possible
     ## for an application to make an entry here too.


### PR DESCRIPTION
Whoops that was supposed to be an array. It was causing an error when multiple types of reboot were queued. Also added a Try/Catch to Get-WindowsEdition b/c it was erroring on some machines.