### PR TITLE
Just adjusted to be compatible with the new Get-DesktopWindowsVersionComparison

### DIFF
--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Download.ps1
@@ -238,11 +238,12 @@ function Start-FileDownload {
 This script should only execute if this machine is a windows 10 machine that is on a version less than the requested version
 #>
 
-# Call in Get-Win10VersionComparison
-(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
+# TODO: Switch to Master branch
+# Call in Get-DesktopWindowsVersionComparison
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/swap-windows-build-IDs-from-20H2-to-19042/Function.Get-DesktopWindowsVersionComparison.ps1') | Invoke-Expression
 
 Try {
-    $lessThanRequestedBuild = Get-Win10VersionComparison -LessThan $automateWin10Build
+    $lessThanRequestedBuild = Get-DesktopWindowsVersionComparison -LessThan $automateWin10Build -UseVersion
 } Catch {
     $outputLog += Get-ErrorMessage $_ "!Error: There was an issue when comparing the current version of windows to the requested one. Cannot continue."
     Invoke-Output $outputLog

--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Install.ps1
@@ -231,11 +231,12 @@ $outputLog += Set-TLS
 This script should only execute if this machine is a windows 10 machine that is on a version less than the requested version
 #>
 
-# Call in Get-Win10VersionComparison
-(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
+# TODO: Switch to Master branch
+# Call in Get-DesktopWindowsVersionComparison
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/swap-windows-build-IDs-from-20H2-to-19042/Function.Get-DesktopWindowsVersionComparison.ps1') | Invoke-Expression
 
 Try {
-    $lessThanRequestedBuild = Get-Win10VersionComparison -LessThan $automateWin10Build
+    $lessThanRequestedBuild = Get-DesktopWindowsVersionComparison -LessThan $automateWin10Build -UseVersion
 } Catch {
     $outputLog += Get-ErrorMessage $_ "There was an issue when comparing the current version of windows to the requested one."
     $outputLog = "!Error: Exiting script.", $outputLog


### PR DESCRIPTION
Should be functionally equivalent, as the new function behaves identically to before if you provide the `UseVersion` switch.

Dependent on https://github.com/dkbrookie/PowershellFunctions/pull/17