### PR TITLE
Add targetWindowsBuild to output of compliance script

### DIFF
--- a/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Compliance_Check.ps1
+++ b/Windows_10_Staging/Powershell/Windows_10_Upgrade_V4/Windows_10_Upgrade_V4_Compliance_Check.ps1
@@ -3,6 +3,7 @@ $outputObject = @{
   outputLog = @()
   nonComplianceReason = ''
   compliant = '0'
+  targetWindowsBuild = ''
 }
 
 If (!$releaseChannel) {
@@ -51,6 +52,7 @@ function Get-ErrorMessage {
 # Determine target via release channel
 Try {
   $targetWindowsBuild = (Get-OsVersionDefinitions).Windows.Desktop[$releaseChannel]
+  $outputObject.targetWindowsBuild = $targetWindowsBuild
 } Catch {
   $outputLog += Get-ErrorMessage $_ 'Function Get-OsVersionDefinitions errored out for some reason.'
   $outputObject.outputLog = $outputLog


### PR DESCRIPTION
Add targetWindowsBuild to output of compliance script

This script is not in production so going to merge without review.