### PR TITLE
handle `Error` and unknown transfer state more better

### DIFF
--- a/Windows_Build_Upgrade/Windows_Build_Upgrade_Download.ps1
+++ b/Windows_Build_Upgrade/Windows_Build_Upgrade_Download.ps1
@@ -505,16 +505,18 @@ If ($jobIdExists -and !(Test-Path -Path $isoFilePath -PathType Leaf)) {
                 }
 
                 Default {
-                    $errorForReg = $jobState
                     $description = $transfer.ErrorDescription
+                    $msg = "The ISO transfer job has entered an unexpected state of '$jobState' and the script can't continue. This machine should be checked out manually."
 
                     If ($description) {
-                        $errorForReg += " $description"
+                        $msg += " Error Description: $description"
                         Write-RegistryValue -Name $downloadErrorKey $description
+                    } Else {
+                        Write-RegistryValue -Name $downloadErrorKey $msg
                     }
 
                     # Not retrying as we want this machine to stand out so we can assess
-                    $outputLog = "!Error: The transfer job has entered an unexpected state and the script can't continue. This machine should be checked out manually. Remove the existing job and assess the reason. Check the job with JobId '$jobId'. Exiting Script. The status message is: $errorForReg" + $outputLog
+                    $outputLog = "!Error: $msg Remove the existing job and assess the reason. Check the job with JobId '$jobId'. Exiting Script." + $outputLog
                     Invoke-Output $outputLog
                     Return
                 }

--- a/Windows_Build_Upgrade/Windows_Build_Upgrade_Download.ps1
+++ b/Windows_Build_Upgrade/Windows_Build_Upgrade_Download.ps1
@@ -3,10 +3,10 @@ $outputLog = @()
 # cast $targetBuild into a string just in case it's an int
 [string]$targetBuild = $targetBuild
 
-# TODO: (for future PR, not now) Research/test what happens when a machine is still pending reboot for 20H2 and then you try to install 21H1.
 # TODO: (for future PR, not now) make reboot handling more robust
 # TODO: (for future PR, not now) After machine is successfully upgraded, new monitor for compliant machines to clean up registry entries and ISOs
 # TODO: (for future PR, not now) Mark reboot pending in EDF. Once reboot is pending, don't run download script anymore.
+# TODO: (for future PR, not now) create ticket or take some other action when error state is unknown and won't retry
 
 <#
 #############

--- a/Windows_Build_Upgrade/Windows_Build_Upgrade_Install.ps1
+++ b/Windows_Build_Upgrade/Windows_Build_Upgrade_Install.ps1
@@ -163,9 +163,9 @@ If ($releaseChannel) {
     If (!$targetBuild) {
         $outputLog = "!Error: Target Build was not found! Please check the provided `$releaseChannel of $releaseChannel against the valid release channels in Get-OsVersionDefinitions in the Constants repository." + $outputLog
         Invoke-Output @{
-        outputLog = $outputLog
-        installationAttemptCount = $installationAttemptCount
-    }
+            outputLog = $outputLog
+            installationAttemptCount = $installationAttemptCount
+        }
         Return
     }
 

--- a/Windows_Build_Upgrade/Windows_Build_Upgrade_Install.ps1
+++ b/Windows_Build_Upgrade/Windows_Build_Upgrade_Install.ps1
@@ -3,11 +3,11 @@ $outputLog = @()
 # cast $targetBuild into a string just in case it's an int
 [string]$targetBuild = $targetBuild
 
-# TODO: (for future PR, not now) Research/test what happens when a machine is still pending reboot for 20H2 and then you try to install 21H1.
 # TODO: (for future PR, not now) make reboot handling more robust
 # TODO: (for future PR, not now) After machine is successfully upgraded, new monitor for compliant machines to clean up registry entries and ISOs
 # TODO: (for future PR, not now) Mark reboot pending in EDF. Once reboot is pending, don't run download script anymore.
 # TODO: (NOW, when prod merge occurs) Rename EDF for 21H2 installationAttemptCount to "current build" and delete the others
+# TODO: (for future PR, not now) create ticket or take some other action when error state is unknown and won't retry
 
 <#
 #############

--- a/Windows_Build_Upgrade/Windows_Build_Upgrade_Install.ps1
+++ b/Windows_Build_Upgrade/Windows_Build_Upgrade_Install.ps1
@@ -183,9 +183,9 @@ If ($releaseChannel) {
     } Else {
         $outputLog = "!Error: An unsupported `$windowsGeneration value of $windowsGeneration was provided. Please choose either '10' or '11'." + $outputLog
         Invoke-Output @{
-        outputLog = $outputLog
-        installationAttemptCount = $installationAttemptCount
-    }
+            outputLog = $outputLog
+            installationAttemptCount = $installationAttemptCount
+        }
         Return
     }
 
@@ -203,9 +203,9 @@ If ($targetBuild) {
     } Else {
         $outputLog = "!Error: There was a problem with the script. `$targetBuild of $targetBuild does not appear to be supported. Please update script!" + $outputLog
         Invoke-Output @{
-        outputLog = $outputLog
-        installationAttemptCount = $installationAttemptCount
-    }
+            outputLog = $outputLog
+            installationAttemptCount = $installationAttemptCount
+        }
         Return
     }
 
@@ -214,9 +214,9 @@ If ($targetBuild) {
     If (!$targetVersion) {
         $outputLog += "No value for `$targetVersion could be determined from `$targetBuild. This script needs to be updated to handle $targetBuild! Please update script!"
         Invoke-Output @{
-        outputLog = $outputLog
-        installationAttemptCount = $installationAttemptCount
-    }
+            outputLog = $outputLog
+            installationAttemptCount = $installationAttemptCount
+        }
         Return
     }
 }


### PR DESCRIPTION
When `bitstransfer` experiences `Error` state or ends up in an unknown state that includes an `ErrorDescription`, save the `ErrorDescription` to the registry and report that error as a possible `nonComplianceReason` in compliance_check script

When in `Error` state, if `ErrorDescription` includes text `*Range protocol*` remove download and retry as this is a known error that can be dependent on client environment (subject to change) and could resolve itself. If `ErrorDescription` does not include that text, leave machine in error state and do not retry in an attempt to highlight the issue.


---
~~Remove TODO: (this is done, doesn't cause any issues) Research/test what happens when a machine is still pending reboot for 20H2 and then you try to install 21H1.~~

Add TODO: (for future PR) create ticket or take some other action when error state is unknown and won't retry